### PR TITLE
Add support for intercepting methods

### DIFF
--- a/manifold-core-parent/manifold/src/main/java/manifold/api/gen/SrcAnnotationArrayExpression.java
+++ b/manifold-core-parent/manifold/src/main/java/manifold/api/gen/SrcAnnotationArrayExpression.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.api.gen;
+
+public class SrcAnnotationArrayExpression extends SrcAnnotationExpression
+{
+  public SrcAnnotationArrayExpression( String fqn )
+  {
+    super( fqn );
+  }
+
+  public SrcAnnotationArrayExpression( Class type )
+  {
+    super( type.getName() );
+  }
+
+  public SrcAnnotationExpression copy()
+  {
+    SrcAnnotationArrayExpression copy = new SrcAnnotationArrayExpression( getAnnotationType() );
+    for( SrcArgument expr : getArguments() )
+    {
+      copy.addArgument( expr.copy() );
+    }
+    return copy;
+  }
+
+  @Override
+  public StringBuilder render( StringBuilder sb, int indent, boolean sameLine )
+  {
+    indent( sb, indent );
+    sb.append( '{' );
+    for( int i = 0; i < getArguments().size(); i++ )
+    {
+      if( i > 0 )
+      {
+        sb.append( ", " );
+      }
+      SrcArgument arg = getArguments().get( i );
+      arg.render( sb, 0 );
+    }
+    sb.append( '}' );
+    return sb;
+  }
+}

--- a/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/ExtensionMethod.java
+++ b/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/ExtensionMethod.java
@@ -43,6 +43,15 @@ public @interface ExtensionMethod
   String isSmartStatic = "isSmartStatic";
   boolean isSmartStatic();
 
+  /**
+   * True if the method is intercepted, and it body needs to be rewritten. See {@link manifold.ext.rt.api.Intercept}
+   */
   String isIntercept = "isIntercept";
   boolean isIntercept();
+
+  /**
+   * True if the origin of the method is from an (unannotated) class. See {@link manifold.ext.rt.api.ExtensionSource}
+   */
+  String isExtensionSource = "isExtensionSource";
+  boolean isExtensionSource();
 }

--- a/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/ExtensionMethodType.java
+++ b/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/ExtensionMethodType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.ext.rt.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+public enum ExtensionMethodType
+{
+    INCLUDE, EXCLUDE;
+}

--- a/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/ExtensionSource.java
+++ b/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/ExtensionSource.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.ext.rt.api;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Use this annotation to indicate a class is a class which methods can be used
+ * as Manifold Extension methods. Methods don't need to be annotated with
+ * {@link Extension}, nor need the method parameters be annotated with {@link This}
+ * or {@link ThisClass}.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Repeatable(value = ExtensionSources.class)
+public @interface ExtensionSource
+{
+    /**
+     * The source class, which contains methods that can be used as Manifold Extension methods
+     */
+    String source = "source";
+    Class source();
+
+    /**
+     * If overrideExistingMethods is true, existing methods can be overridden by extension methods
+     */
+    String overrideExistingMethods = "overrideExistingMethods";
+    boolean overrideExistingMethods() default false;
+
+    /**
+     * When {@link #methods} are configured, the types defines if the methods are included or excluded
+     * to be added as extension methods
+     */
+    String type = "type";
+    ExtensionMethodType type() default ExtensionMethodType.EXCLUDE;
+
+    /**
+     * Definitions of methods to be added or excluded, depending on the {@link #type}
+     */
+    String methods = "methods";
+    MethodSignature[] methods() default { };
+
+}

--- a/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/ExtensionSources.java
+++ b/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/ExtensionSources.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.ext.rt.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+@Retention(RetentionPolicy.CLASS)
+public @interface ExtensionSources
+{
+    ExtensionSource[] value();
+}

--- a/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/MethodSignature.java
+++ b/manifold-deps-parent/manifold-ext-rt/src/main/java/manifold/ext/rt/api/MethodSignature.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.ext.rt.api;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation used to define method signatures, consisting of the method name, and it parameter types
+ */
+@Retention(RetentionPolicy.CLASS)
+public @interface MethodSignature
+{
+    /** The name of the method */
+    String name = "name";
+    String name();
+
+    /** the parameter types of the method */
+    String paramTypes = "paramTypes";
+    Class[] paramTypes();
+}

--- a/manifold-deps-parent/manifold-ext-test/pom.xml
+++ b/manifold-deps-parent/manifold-ext-test/pom.xml
@@ -41,6 +41,24 @@
         <artifactId>junit</artifactId>
         <scope>compile</scope>
       </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>5.11.4</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.11.4</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>3.27.2</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 
     <build>

--- a/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExt.java
+++ b/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExt.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.extensions.java.lang.String;
+
+import manifold.ext.rt.api.Extension;
+import manifold.ext.rt.api.ExtensionMethodType;
+import manifold.ext.rt.api.ExtensionSource;
+import manifold.ext.rt.api.MethodSignature;
+
+@Extension
+@ExtensionSource(
+  source = MyStringExtSource.class,
+  type = ExtensionMethodType.EXCLUDE,
+  overrideExistingMethods = true,
+  methods = {
+    @MethodSignature( name = "startsWith", paramTypes = { String.class, String.class, int.class } )
+    // TODO: Should we include the first 'self' parameter (i.e., the method signature as in MyStringExtSource)?
+    // Or should we define the methods as they appear in the String class?
+  }
+)
+@ExtensionSource(
+  source = MyStringExtSource2.class,
+  type = ExtensionMethodType.INCLUDE,
+  overrideExistingMethods = true,
+  methods = {
+    @MethodSignature( name = "substring", paramTypes = { String.class, int.class } )
+  }
+)
+@ExtensionSource( source = MyStringExtSource3.class, overrideExistingMethods = true )
+public class MyStringExt
+{
+}
+

--- a/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExtSource.java
+++ b/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExtSource.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.extensions.java.lang.String;
+
+public class MyStringExtSource
+{
+  public static String trim( String text )
+  {
+    return text == null ? null : text.trim();
+  }
+
+  public static boolean startsWith( String text, String prefix )
+  {
+    return text != null && text.startsWith( prefix );
+  }
+
+  public static boolean startsWith( String text, String prefix, int toffset )
+  {
+    return text != null && text.startsWith( prefix, toffset );
+  }
+}
+

--- a/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExtSource2.java
+++ b/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExtSource2.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.extensions.java.lang.String;
+
+public class MyStringExtSource2
+{
+  public static String substring( String text, int beginIndex )
+  {
+    return text == null ? null : text.substring( beginIndex );
+  }
+
+  public static String substring( String text, int beginIndex, int endIndex )
+  {
+    return text == null ? null : text.substring( beginIndex, endIndex );
+  }
+}
+

--- a/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExtSource3.java
+++ b/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/lang/String/MyStringExtSource3.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.extensions.java.lang.String;
+
+public class MyStringExtSource3
+{
+  public static String toLowerCase( String text )
+  {
+    return text == null ? null : text.toLowerCase();
+  }
+}
+

--- a/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/nio/file/Path/MyPathExt.java
+++ b/manifold-deps-parent/manifold-ext-test/src/main/java/manifold/extensions/java/nio/file/Path/MyPathExt.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 - Manifold Systems LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manifold.extensions.java.nio.file.Path;
+
+import java.nio.file.Files;
+
+import manifold.ext.rt.api.Extension;
+import manifold.ext.rt.api.ExtensionSource;
+
+
+@Extension
+@ExtensionSource( source = Files.class )
+public class MyPathExt
+{
+}
+

--- a/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/ExtensionSourceTest.java
+++ b/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/ExtensionSourceTest.java
@@ -1,0 +1,48 @@
+package manifold.ext;
+
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ExtensionSourceTest
+{
+  @Test
+  void testExtensionSources()
+  {
+    String nullString = null;
+    String text = "  abc  FoO bar ";
+
+    // extensions from MyStringExtSource \\
+
+    // overridden method should not throw an exception
+    assertThat( nullString.trim() ).isNull();
+    assertThat( text.trim() ).isEqualTo( "abc  FoO bar" );
+
+    // overridden method should not throw an exception
+    assertThat( nullString.startsWith( "  abc" ) ).isFalse();
+    assertThat( text.startsWith( "  abc" ) ).isTrue();
+    // Excluded method isn't overridden and should still throw a nullpointer exception
+    assertThatNullPointerException().isThrownBy( () -> nullString.startsWith( "  abc", 2 ) );
+
+    /// //////////////////////////////////
+
+    // extensions from MyStringExtSource2 \\
+
+    // only included method is overridden and should not throw an exception
+    assertThat( nullString.substring( 6 ) ).isNull();
+    assertThat( text.substring( 6 ) ).isEqualTo( " FoO bar " );
+
+    // other methods aren't included and are still throwing a NPE
+    assertThatNullPointerException().isThrownBy( () -> nullString.substring( 6, 10 ) );
+    assertThat( text.substring( 6, 10 ) ).isEqualTo( " FoO" );
+
+    /// //////////////////////////////////
+
+    // extensions from MyStringExtSource3 \\
+
+    // All methods are included, nothing is configured
+    assertThat( nullString.toLowerCase() ).isNull();
+    assertThat( text.toLowerCase() ).isEqualTo( "  abc  foo bar " );
+  }
+}

--- a/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/SimpleTest.java
+++ b/manifold-deps-parent/manifold-ext-test/src/test/java/manifold/ext/SimpleTest.java
@@ -4,6 +4,7 @@ import abc.*;
 
 import java.awt.Rectangle;
 import java.io.Serializable;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
@@ -58,6 +59,11 @@ public class SimpleTest extends TestCase
     ContributorKind.Primary.hiContributorKind();
     ClassType.Enum.hiClassType();
     new BasicIncrementalCompileDriver(true).hiBasic();
+  }
+
+  public void testExtensionUtilityClass(){
+    // isDirectory method should exist
+    assertFalse(Paths.get("X:\\invalid_path").isDirectory());
   }
 
   public void testSelfTypeOnExtension()

--- a/manifold-deps-parent/manifold-ext/README.md
+++ b/manifold-deps-parent/manifold-ext/README.md
@@ -717,11 +717,68 @@ to your project separately depending on its needs.
 >}
 >```
 
-## Generating Extension Classes
+## Using Utility Class Methods as Extensions
 
-Sometimes the contents of an extension class reflect metadata from other resources.  In this case rather 
-than painstakingly writing such classes by hand it's easier and less error-prone to produce them via 
-type manifold.  To facilitate this use-case, your type manifold must implement the `IExtensionClassProducer`
+Methods in utility classes are often good candidates to be used as extension methods. 
+However, since these methods are not annotated, they cannot be used directly as extension methods.
+
+Rather than manually converting all those methods into extensions, which can be time-consuming and error-prone,
+you can leverage Manifold's built-in functionality to automate this process. 
+By specifying the utility class as a parameter to the `@ExtensionSource` annotation, 
+you can easily incorporate its methods as extension methods for the target type.
+
+### Basic Usage
+Suppose you want to use methods from the `org.apache.commons.lang3.StringUtils` class as extension methods for
+`java.lang.String`. You can do this with the following code:
+
+```java
+package extensions.java.lang.String;
+
+import java.org.apache.commons.lang3.StringUtils;
+import manifold.ext.rt.api.Extension;
+import manifold.ext.rt.api.ExtensionSource;
+
+@Extension
+@ExtensionSource( source = StringUtils.class )
+public class MyStringExt {
+    // Additional extension methods can be added here
+}
+```
+With this approach, all `public`, `static` methods from the `StringUtils` class that take a `String` as their first 
+parameter will be automatically available as extension methods for `String` objects.
+Any methods that conflict with existing methods in the `String` class (i.e., methods with the same signature) 
+will be excluded by default.
+
+### Overriding Existing Methods
+If you want to override existing methods (i.e., make the methods from the utility class replace the methods already present on the target object), 
+you can set the `overrideExistingMethods` attribute to `true`:
+
+
+```java
+@ExtensionSource( source = Files.class, overrideExistingMethods = true )
+```
+### Granular Control Over Included and Excluded Methods
+
+You can further control which methods are included or excluded by specifying the method signatures you want to include or exclude. 
+This is achieved using the `type` and `methods` attributes in the `@ExtensionSource` annotation.
+
+For example, to include (or exclude) only specific methods from `StringUtils`, you can specify the `INCLUDE` or `EXCLUDE` types and provide method signatures:
+
+```java
+@ExtensionSource( 
+    source = StringUtils.class,
+    overrideExistingMethods = true,
+    type = ExtensionMethodType.INCLUDE, // <-- change to EXCLUDE to exclude specified methods
+    methods = {
+        @MethodSignature( name = "substring", paramTypes = { String.class, int.class } )
+        // others
+    } )
+```
+
+### Manually Generating Extension Classes
+
+Manifold also provides the option to manually generate extension classes by creating your own type manifolds.
+To do this, your type manifold must implement the `IExtensionClassProducer`
 interface so that the `ExtensionManifold` can discover information about the classes your type
 manifold produces. For the typical use case your type manifold should extend `AbstractExtensionProducer`.
 


### PR DESCRIPTION
## Using Utility Class Methods as Extensions
Methods in utility classes are often good candidates to be used as extension methods. 
However, since these methods are not annotated, they cannot be used directly as extension methods.
Rather than manually converting all those methods into extensions, which can be time-consuming and error-prone,
you can leverage Manifold's built-in functionality to automate this process. 
By specifying the utility class as a parameter to the `@ExtensionSource` annotation, 
you can easily incorporate its methods as extension methods for the target type.
### Basic Usage
Suppose you want to use methods from the `org.apache.commons.lang3.StringUtils` class as extension methods for
`java.lang.String`. You can do this with the following code:
```java
package extensions.java.lang.String;
import java.org.apache.commons.lang3.StringUtils;
import manifold.ext.rt.api.Extension;
import manifold.ext.rt.api.ExtensionSource;
@Extension
@ExtensionSource( source = StringUtils.class )
public class MyStringExt {
    // Additional extension methods can be added here
}
```
With this approach, all `public`, `static` methods from the `StringUtils` class that take a `String` as their first 
parameter will be automatically available as extension methods for `String` objects.
Any methods that conflict with existing methods in the `String` class (i.e., methods with the same signature) 
will be excluded by default.

### Overriding Existing Methods
If you want to override existing methods (i.e., make the methods from the utility class replace the methods already present on the target object), 
you can set the `overrideExistingMethods` attribute to `true`:


```java
@ExtensionSource( source = Files.class, overrideExistingMethods = true )
```
### Granular Control Over Included and Excluded Methods

You can further control which methods are included or excluded by specifying the method signatures you want to include or exclude. 
This is achieved using the `type` and `methods` attributes in the `@ExtensionSource` annotation.

For example, to include (or exclude) only specific methods from `StringUtils`, you can specify the `INCLUDE` or `EXCLUDE` types and provide method signatures:

```java
@ExtensionSource( 
    source = StringUtils.class,
    overrideExistingMethods = true,
    type = ExtensionMethodType.INCLUDE, // <-- change to EXCLUDE to exclude specified methods
    methods = {
        @MethodSignature( name = "substring", paramTypes = { String.class, int.class } )
        // others
    } )
```